### PR TITLE
[WIP] Initial integration testing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,6 +67,12 @@ checksum = "e3c69b077ad434294d3ce9f1f6143a2a4b89a8a2d54ef813d85003a4fd1137fd"
 
 [[package]]
 name = "cfg-if"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
+name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
@@ -84,6 +90,15 @@ dependencies = [
  "textwrap",
  "unicode-width",
  "vec_map",
+]
+
+[[package]]
+name = "cloudabi"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -118,7 +133,7 @@ version = "0.8.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80df024fbc5ac80f87dfef0d9f5209a252f2a497f7f42944cff24d8253cac065"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -206,7 +221,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "wasi",
 ]
@@ -377,12 +392,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9385f66bf6105b241aa65a61cb923ef20efc665cb9f9bb50ac2f0c4b7f378d41"
 
 [[package]]
+name = "lock_api"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4da24a77a3d8a6d4862d95f72e6fdb9c09a643ecdb402d754004a557f2bec75"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -451,7 +475,7 @@ checksum = "fa9b4819da1bc61c0ea48b63b7bc8604064dd43013e7cc325df098d49cd7c18a"
 dependencies = [
  "bitflags",
  "cc",
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
 ]
 
@@ -487,7 +511,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a61075b62a23fef5a29815de7536d940aa35ce96d18ce0cc5076272db678a577"
 dependencies = [
  "bitflags",
- "cfg-if",
+ "cfg-if 1.0.0",
  "foreign-types",
  "libc",
  "once_cell",
@@ -511,6 +535,30 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3a704eb390aafdc107b0e392f56a82b668e3a71366993b5340f5833fd62505e"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d58c7c768d4ba344e3e8d72518ac13e259d7c7ade24167003b8488e10b6740a3"
+dependencies = [
+ "cfg-if 0.1.10",
+ "cloudabi",
+ "libc",
+ "redox_syscall 0.1.57",
+ "smallvec",
+ "winapi",
 ]
 
 [[package]]
@@ -647,6 +695,12 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
+
+[[package]]
+name = "redox_syscall"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94341e4e44e24f6b591b59e47a8a027df12e008d73fd5672dbea9cc22f4507d9"
@@ -704,6 +758,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "serde",
+ "serde_json",
  "serde_urlencoded",
  "tokio",
  "tokio-native-tls",
@@ -729,6 +784,12 @@ dependencies = [
  "lazy_static",
  "winapi",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "security-framework"
@@ -797,10 +858,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial_test"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fef5f7c7434b2f2c598adc6f9494648a1e41274a75c0ba4056f680ae0c117fd6"
+dependencies = [
+ "lazy_static",
+ "parking_lot",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d08338d8024b227c62bd68a12c7c9883f5c66780abaef15c550dc56f46ee6515"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
+
+[[package]]
+name = "smallvec"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
 name = "socket2"
@@ -835,10 +924,10 @@ version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "rand",
- "redox_syscall",
+ "redox_syscall 0.2.5",
  "remove_dir_all",
  "winapi",
 ]
@@ -878,9 +967,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134af885d758d645f0f0505c9a8b3f9bf8a348fd822e112ab5248138348f1722"
+checksum = "83f0c8e7c0addab50b663055baf787d0af7f413a46e6e7fb9559a4e4db7137a5"
 dependencies = [
  "autocfg",
  "bytes",
@@ -927,7 +1016,7 @@ version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01ebdc2bb4498ab1ab5f5b73c5803825e60199229ccba0698170e3be0e7f959f"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "pin-project-lite",
  "tracing-core",
 ]
@@ -951,6 +1040,8 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "serial_test",
+ "tempfile",
  "threadpool",
  "validator",
 ]
@@ -1082,7 +1173,7 @@ version = "0.2.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83240549659d187488f91f33c0f8547cbfef0b2088bc470c116d1d260ef623d9"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "serde",
  "serde_json",
  "wasm-bindgen-macro",
@@ -1109,7 +1200,7 @@ version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81b8b767af23de6ac18bf2168b690bed2902743ddf0fb39252e36f9e2bfc63ea"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "js-sys",
  "wasm-bindgen",
  "web-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,10 @@ edition = "2018"
 clap = "2.33.3"
 ctrlc = "3.1.8"
 lazy_static = "1.4.0"
-reqwest = { version = "0.11.0", features = ["blocking"] }
-serde = {version = "1.0.125", features = ["derive"] }
+reqwest = { version = "0.11.0", features = ["blocking", "json"] }
+serial_test = "0.4.0"
+serde = { version = "1.0.125", features = ["derive"] }
 serde_json = "1.0.59"
+tempfile = "3.2.0"
 threadpool = "1.8.1"
 validator = { version = "0.13.0", features = ["derive"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,22 @@
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        assert_eq!(2 + 2, 4);
-    }
+#[macro_use]
+extern crate lazy_static;
+
+use std::env;
+mod cli;
+pub use cli::TrinConfig;
+mod jsonrpc;
+pub use jsonrpc::launch_trin;
+
+pub fn entry() {
+    let trin_config = TrinConfig::new();
+
+    let infura_project_id = match env::var("TRIN_INFURA_PROJECT_ID") {
+        Ok(val) => val,
+        Err(_) => panic!(
+            "Must supply Infura key as environment variable, like:\n\
+            TRIN_INFURA_PROJECT_ID=\"your-key-here\" trin"
+        ),
+    };
+
+    launch_trin(trin_config, infura_project_id);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,22 +1,5 @@
-#[macro_use]
-extern crate lazy_static;
-
-use std::env;
-mod cli;
-use cli::TrinConfig;
-mod jsonrpc;
-use jsonrpc::launch_trin;
+use trin::entry;
 
 fn main() {
-    let trin_config = TrinConfig::new();
-
-    let infura_project_id = match env::var("TRIN_INFURA_PROJECT_ID") {
-        Ok(val) => val,
-        Err(_) => panic!(
-            "Must supply Infura key as environment variable, like:\n\
-            TRIN_INFURA_PROJECT_ID=\"your-key-here\" trin"
-        ),
-    };
-
-    launch_trin(trin_config, infura_project_id);
+    entry();
 }

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,0 +1,8 @@
+use serde::Deserialize;
+
+#[derive(Deserialize, Debug)]
+pub struct JsonResponse {
+    pub jsonrpc: String,
+    pub id: String,
+    pub result: String,
+}

--- a/tests/http_cli.rs
+++ b/tests/http_cli.rs
@@ -1,0 +1,77 @@
+mod common;
+use common::JsonResponse;
+use reqwest;
+use serde_json;
+use serial_test::serial;
+use std::collections::HashMap;
+use std::ffi::OsStr;
+use std::process::Command;
+use std::{thread, time};
+
+#[test]
+#[serial]
+fn test_client_version() {
+    let bin_path = OsStr::new("./target/debug/trin");
+    let mut handle = Command::new(bin_path)
+        .spawn()
+        .expect("trin subprocess failed to launch");
+
+    let mut map = HashMap::new();
+    map.insert("jsonrpc", "2.0");
+    map.insert("id", "1");
+    map.insert("method", "web3_clientVersion");
+
+    // sleep for a second to allow subprocess to start
+    let one_second = time::Duration::from_secs(1);
+    thread::sleep(one_second);
+
+    let client = reqwest::blocking::Client::new();
+    let res = client.post("http://127.0.0.1:8545").json(&map).send();
+
+    let response: JsonResponse = match res {
+        Ok(val) => serde_json::from_str(&val.text().unwrap()).unwrap(),
+        Err(msg) => {
+            handle.kill().unwrap();
+            panic!("Failed test, test_client_version: {}", msg);
+        }
+    };
+
+    handle.kill().unwrap();
+    assert_eq!(response.jsonrpc, "2.0");
+    assert_eq!(response.id, "1");
+    assert_eq!(response.result, "trin 0.0.1-alpha");
+}
+
+#[test]
+#[serial]
+fn test_block_number() {
+    let bin_path = OsStr::new("./target/debug/trin");
+    let mut handle = Command::new(bin_path)
+        .spawn()
+        .expect("trin subprocess failed to launch");
+
+    let mut map = HashMap::new();
+    map.insert("jsonrpc", "2.0");
+    map.insert("id", "1");
+    map.insert("method", "eth_blockNumber");
+
+    let one_second = time::Duration::from_secs(1);
+    thread::sleep(one_second);
+
+    let client = reqwest::blocking::Client::new();
+    let res = client.post("http://127.0.0.1:8545").json(&map).send();
+
+    let response = match res {
+        Ok(val) => val.text(),
+        Err(msg) => {
+            handle.kill().unwrap();
+            panic!("test_block_number test failed: {}", msg);
+        }
+    };
+
+    let response: JsonResponse = serde_json::from_str(&response.unwrap()).unwrap();
+    handle.kill().unwrap();
+    assert_eq!(response.jsonrpc, "2.0");
+    assert_eq!(response.id, "1");
+    assert!(response.result.contains("0x"));
+}

--- a/tests/ipc_cli.rs
+++ b/tests/ipc_cli.rs
@@ -1,0 +1,84 @@
+mod common;
+use common::JsonResponse;
+use serde_json;
+use serial_test::serial;
+use std::ffi::OsStr;
+use std::io::prelude::*;
+use std::os::unix::net::UnixStream;
+use std::process::Command;
+use std::{thread, time};
+use tempfile::tempdir;
+
+#[test]
+#[serial]
+fn test_client_version() {
+    let tmpdir = tempdir().unwrap();
+    let tmp = tmpdir.path().join("trin-jsonrpc.ipc");
+    let path = tmp.into_os_string();
+
+    let bin_path = OsStr::new("./target/debug/trin");
+    let mut handle = Command::new(bin_path)
+        .arg("-p")
+        .arg("ipc")
+        .arg("-i")
+        .arg(&path)
+        .spawn()
+        .expect("trin subprocess failed to launch");
+
+    // sleep for a second to allow subprocess to start
+    let one_second = time::Duration::from_secs(1);
+    thread::sleep(one_second);
+
+    let mut stream = UnixStream::connect(path).unwrap();
+    let request = br#"{"jsonrpc":"2.0","id":"1","method":"web3_clientVersion"}"#;
+    stream.write_all(request).unwrap();
+
+    let mut buf = [0; 1024];
+    stream.read(&mut buf).unwrap();
+
+    handle.kill().unwrap();
+    tmpdir.close().unwrap();
+
+    let raw_response = std::str::from_utf8(&buf).unwrap();
+    let formatted_response = raw_response.trim_end_matches("\u{0}");
+    let response: JsonResponse = serde_json::from_str(&formatted_response).unwrap();
+    assert_eq!(response.jsonrpc, "2.0");
+    assert_eq!(response.id, "1");
+    assert_eq!(response.result, "trin 0.0.1-alpha");
+}
+
+#[test]
+#[serial]
+fn test_block_number() {
+    let tmpdir = tempdir().unwrap();
+    let tmp = tmpdir.path().join("trin-jsonrpc.ipc");
+    let path = tmp.into_os_string();
+
+    let bin_path = OsStr::new("./target/debug/trin");
+    let mut handle = Command::new(bin_path)
+        .arg("-p")
+        .arg("ipc")
+        .arg("-i")
+        .arg(&path)
+        .spawn()
+        .expect("trin subprocess failed to launch");
+
+    // sleep for a second to allow subprocess to start
+    let one_second = time::Duration::from_secs(1);
+    thread::sleep(one_second);
+
+    let mut stream = UnixStream::connect(path).unwrap();
+    let request = br#"{"jsonrpc":"2.0","id":"1","method":"eth_blockNumber"}"#;
+    stream.write_all(request).unwrap();
+
+    let mut buf = [0; 1024];
+    stream.read(&mut buf).unwrap();
+    handle.kill().unwrap();
+    tmpdir.close().unwrap();
+    let raw_response = std::str::from_utf8(&buf).unwrap();
+    let formatted_response = raw_response.trim_end_matches("\u{0}");
+    let response: JsonResponse = serde_json::from_str(&formatted_response).unwrap();
+    assert_eq!(response.jsonrpc, "2.0");
+    assert_eq!(response.id, "1");
+    assert!(response.result.contains("0x"));
+}


### PR DESCRIPTION
Fixes #4 .
Integration tests for the `web3_clientVersion` and `eth_blockNumber` endpoints - for both http and ipc protocols.

- tests are run synchronously using `serial` package. this slows down tests significantly, however the overhead of configuring each test to not interfere with the others as they are run in parallel justifies the speed tradeoff imo. 
- I've created an infura project id and updated the environment variable in circleci
