### PR TITLE
Rename CLI arguments for disambiguation

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,12 @@ In a python shell:
 ```
 
 ### Connect over HTTP
-In a python shell:
+First launch trin using HTTP as the json-rpc transport protocol:
+```sh
+TRIN_INFURA_PROJECT_ID="YoUr-Id-HeRe" cargo run -- --web3-transport http
+```
+
+Then, in a python shell:
 ```py
 >>> from web3 import Web3
 >>> w3 = Web3(Web3.HTTPProvider("http://127.0.0.1:8545"))
@@ -68,20 +73,21 @@ nc -U /tmp/trin-jsonrpc.ipc
 ```sh
 trin 0.0.1
 carver
-super lightweight eth portal
+Run an eth portal client
 
 USAGE:
     trin [OPTIONS]
 
 FLAGS:
-        --help       Prints help information
+    -h, --help       Prints help information
     -V, --version    Prints version information
 
 OPTIONS:
-    -h, --http-port <http_port>    port to accept http connections [default: 8545]
-    -i, --ipc-path <ipc_path>      path to IPC location [default: /tmp/trin-jsonrpc.ipc]
-    -s, --pool-size <pool_size>    max size of threadpool [default: 2]
-    -p, --protocol <protocol>      select transport protocol [default: http]  [possible values: http, ipc]
+        --pool-size <pool_size>              max size of threadpool [default: 2]
+        --web3-http-port <web3_http_port>    port to accept json-rpc http connections [default: 8545]
+        --web3-ipc-path <web3_ipc_path>      path to json-rpc endpoint over IPC [default: /tmp/trin-jsonrpc.ipc]
+        --web3-transport <web3_transport>    select transport protocol to serve json-rpc endpoint [default: ipc]
+                                             [possible values: http, ipc]
 ```
 
 ## Gotchas

--- a/src/jsonrpc.rs
+++ b/src/jsonrpc.rs
@@ -16,10 +16,10 @@ lazy_static! {
 pub fn launch_trin(trin_config: TrinConfig, infura_project_id: String) {
     let pool = ThreadPool::new(trin_config.pool_size as usize);
 
-    match trin_config.protocol.as_str() {
-        "ipc" => launch_ipc_client(pool, infura_project_id, &trin_config.ipc_path),
+    match trin_config.web3_transport.as_str() {
+        "ipc" => launch_ipc_client(pool, infura_project_id, &trin_config.web3_ipc_path),
         "http" => launch_http_client(pool, infura_project_id, trin_config),
-        val => panic!("Unsupported protocol: {}", val),
+        val => panic!("Unsupported web3 transport: {}", val),
     }
 }
 
@@ -102,7 +102,7 @@ fn serve_ipc_client(rx: &mut impl Read, tx: &mut impl Write, infura_url: &str) {
 }
 
 fn launch_http_client(pool: ThreadPool, infura_project_id: String, trin_config: TrinConfig) {
-    let uri = format!("127.0.0.1:{}", trin_config.http_port);
+    let uri = format!("127.0.0.1:{}", trin_config.web3_http_port);
     let listener = TcpListener::bind(uri).unwrap();
     for stream in listener.incoming() {
         match stream {


### PR DESCRIPTION
There will be ports used on both the p2p endpoint and the json-rpc
endpoint. It's too ambiguous to have a CLI argument of simply "http
port".

Also, single-letter flags are too short to handle the argument
complexity that's coming. Not to mention that we should not overwrite
the -h (help) arg.