### PR TITLE
Try to ping the bootnodes on the overlay network, at launch time

### DIFF
--- a/src/alexandria/discovery.rs
+++ b/src/alexandria/discovery.rs
@@ -28,7 +28,7 @@ impl Default for Config {
 pub type ProtocolRequest = Vec<u8>;
 
 pub struct Discovery {
-    discv5: Discv5,
+    pub discv5: Discv5,
     /// Indicates if the discv5 service has been started
     pub started: bool,
 }

--- a/src/alexandria/protocol.rs
+++ b/src/alexandria/protocol.rs
@@ -29,7 +29,7 @@ impl Default for PortalConfig {
     }
 }
 
-pub const PROTOCOL: &str = "state-network";
+pub const PROTOCOL: &str = "portal";
 
 pub struct AlexandriaProtocol {
     discovery: Discovery,

--- a/src/alexandria/protocol.rs
+++ b/src/alexandria/protocol.rs
@@ -143,7 +143,7 @@ impl AlexandriaProtocol {
             Request::Ping(Ping { .. }) => {
                 let enr_seq = self.discovery.local_enr().seq();
                 Response::Pong(Pong {
-                    enr_seq: enr_seq as u32,
+                    enr_seq: enr_seq,
                     data_radius: self.data_radius,
                 })
             }

--- a/src/alexandria/types.rs
+++ b/src/alexandria/types.rs
@@ -116,13 +116,13 @@ impl Response {
 
 #[derive(Debug, PartialEq, Clone, Encode, Decode)]
 pub struct Ping {
-    pub enr_seq: u32,
+    pub enr_seq: u64,
     pub data_radius: U256,
 }
 
 #[derive(Debug, PartialEq, Clone, Encode, Decode)]
 pub struct Pong {
-    pub enr_seq: u32,
+    pub enr_seq: u64,
     pub data_radius: U256,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,8 +39,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         config.bootnode_enrs
     );
     tokio::spawn(async move {
-        let _p2p = AlexandriaProtocol::new(config).await.unwrap();
-        // TODO next hacky test: make sure we establish a session with the boot node
+        let mut p2p = AlexandriaProtocol::new(config).await.unwrap();
+        // hacky test: make sure we establish a session with the boot node
+        p2p.ping_bootnodes().await.unwrap();
 
         // TODO Probably some new API like p2p.maintain_network() that blocks forever
         tokio::time::sleep(Duration::from_secs(86400 * 365 * 10)).await;


### PR DESCRIPTION
This makes for an easier cross-client ping test. Once the handshake is working, the intention would be to immediately start populating the buckets for the overlay network.

Also, fix bug where ENR sequence was only 32 bit.

It should be 64-bit according to discv5 and the spec: 
https://github.com/ethereum/devp2p/blob/6eddaf50298d551a83bcc242e7ce7024c6cc8590/enr.md