### PR TITLE
Log discv5 to stderr

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2023,6 +2023,8 @@ dependencies = [
  "serde_json",
  "threadpool",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
  "uint 0.8.5",
  "validator",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,8 @@ rlp = "0.5.0"
 serde = {version = "1.0.125", features = ["derive"] }
 serde_json = "1.0.59"
 threadpool = "1.8.1"
+tracing = "0.1.26"
+tracing-subscriber = "0.2.18"
 tokio = {version = "1.2.0", features = ["full"]}
 uint = { version = "0.8.5", default-features = false }
 validator = { version = "0.13.0", features = ["derive"] }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -108,6 +108,7 @@ impl TrinConfig {
         println!("Bootnodes: {}", bootnodes);
         let bootnodes: Vec<String> = bootnodes
             .split(',')
+            .filter(|&bootnode| !bootnode.is_empty())
             .map(|bootnode| bootnode.to_string())
             .collect();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 #[macro_use]
 extern crate lazy_static;
 extern crate log;
+extern crate tracing;
 
 mod cli;
 use cli::TrinConfig;
@@ -15,7 +16,7 @@ use portalnet::protocol::{PortalnetConfig, PortalnetProtocol};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    env_logger::init();
+    tracing_subscriber::fmt::init();
 
     let trin_config = TrinConfig::new();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,6 @@ mod jsonrpc;
 use jsonrpc::launch_trin;
 use log::info;
 use std::env;
-use std::time::Duration;
 
 mod portalnet;
 use portalnet::protocol::{PortalnetConfig, PortalnetProtocol};
@@ -54,8 +53,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         // hacky test: make sure we establish a session with the boot node
         p2p.ping_bootnodes().await.unwrap();
 
-        // TODO Probably some new API like p2p.maintain_network() that blocks forever
-        tokio::time::sleep(Duration::from_secs(86400 * 365 * 10)).await;
+        tokio::signal::ctrl_c()
+            .await
+            .expect("failed to pause until ctrl-c");
     })
     .await
     .unwrap();


### PR DESCRIPTION
The `tracing` package doesn't use `env_logger` rules by default. We need to initialize it.

Includes two bonus fixes:
- when `--bootnodes` is empty, or includes empty entries, don't crash
- run until ctrl-c properly, instead of just a very long sleep