### PR TITLE
Fix startup order for discv5 event stream (closes #37)

### DIFF
--- a/src/portalnet/protocol.rs
+++ b/src/portalnet/protocol.rs
@@ -133,13 +133,13 @@ impl PortalnetProtocol {
         };
 
         let mut discovery = Discovery::new(config).unwrap();
+        discovery.start(listen_all_ips).await?;
+
         let protocol_receiver = discovery
             .discv5
             .event_stream()
             .await
             .map_err(|e| e.to_string())?;
-
-        discovery.start(listen_all_ips).await?;
 
         let discovery = Arc::new(discovery);
 


### PR DESCRIPTION
> I probably missed something dumb when I ported to the beta, let me take a look.

Yes, I did something really dumb.