### PR TITLE
Add support for compilation to windows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,7 @@
 version: 2.1
 orbs:
   rust: circleci/rust@1.1.1
+  win: circleci/windows@2.2.0
 jobs:
   lint-build-test:
         description: |
@@ -28,10 +29,14 @@ jobs:
             - run:
                 name: Run rustfmt
                 command: cargo fmt -- --check
-            - rust/clippy:
-                # Force a failure on clippy warnings
-                flags: "-- --deny warnings"
-                with_cache: false
+            # Run the sub-commands of the orb jobs separately, since the combined steps for Clippy can be long enough to trigger a timeout (>10min). Building the source is the main contributor.
+            - run:
+                name: Install Clippy
+                command: rustup component add clippy
+            - run:
+                name: Run Clippy
+                command: cargo clippy -- --deny warnings
+                no_output_timeout: 20m
             - rust/build:
                 release: false
                 with_cache: false
@@ -42,7 +47,53 @@ jobs:
                 paths:
                     - ~/.cargo
                     - target
+  win-build:
+    description: |
+      Build the crate for windows.
+    executor:
+      name: win/default
+      shell: powershell.exe
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - cargo-{{ checksum "Cargo.lock" }}-v1
+      - run:
+          name: Install rustup
+          command: choco install rustup.install
+      - run:
+          name: Install clang
+          command: choco install llvm
+      - run:
+          name: Add target
+          command: rustup target add x86_64-pc-windows-msvc
+      - run:
+          name: Install target toolchain
+          command: rustup toolchain install stable-x86_64-pc-windows-msvc
+      # Run the sub-commands of the orb jobs separately, since the combined steps for Clippy can be long enough to trigger a timeout (>10min). Building the source is the main contributor.
+      - run:
+          name: Install Clippy
+          command: rustup component add clippy
+      - run:
+          name: Run Clippy
+          # Remove the first two lines of gitconfig as work around
+          command: |
+            (gc ..\.gitconfig | select -Skip 2) | sc ..\.gitconfig
+            cargo clippy -- --deny warnings
+          no_output_timeout: 20m
+      - run:
+          name: Cargo Build --target x86_64-pc-windows-msvc
+          command: cargo build --target x86_64-pc-windows-msvc
+      - run:
+          name: Cargo Test --target x86_64-pc-windows-msvc
+          command: cargo test --target x86_64-pc-windows-msvc
+      - save_cache:
+          key: cargo-{{ checksum "Cargo.lock" }}-v1
+          paths:
+            - ~/.cargo
+            - target
 workflows:
   merge-test:
     jobs:
       - lint-build-test
+      - win-build

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ eth2_ssz = "0.1.2"
 eth2_ssz_derive = "0.1.0"
 futures = "0.3.13"
 hex = "0.4.3"
-interfaces = "0.0.7"
 lazy_static = "1.4.0"
 log = "0.4.14"
 reqwest = { version = "0.11.0", features = ["blocking"] }
@@ -30,6 +29,14 @@ tracing-subscriber = "0.2.18"
 tokio = {version = "1.8.0", features = ["full"]}
 uint = { version = "0.8.5", default-features = false }
 validator = { version = "0.13.0", features = ["derive"] }
+
+
+[target.'cfg(windows)'.dependencies]
+ipconfig = "0.2.2"
+uds_windows = "1.0.1"
+
+[target.'cfg(unix)'.dependencies]
+interfaces = "0.0.7"
 
 [dependencies.discv5]
 version = "0.1.0-beta.5"


### PR DESCRIPTION
So currently two parts of the code only support Unix. Most notably is the interfaces library and currently, the std::net library doesn't support Unix domain socket server on windows which was added to windows in 2018. So I wrote windows equivalent functions using libraries that support windows.  I also added a circleci build to test if Trin builds to Windows, I assume we could also add a cross-compile for MacOS in the future.

I think Trin being cross-platform would be important in the future if it ever hits production. Also I use Windows as my host platform so it would be nice if I could build trin natively.

Original post which was way too long: https://hastebin.com/opewikujef.sql