### PR TITLE
Add message channel to serve portal jsonrpc requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2455,9 +2455,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.5.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83f0c8e7c0addab50b663055baf787d0af7f413a46e6e7fb9559a4e4db7137a5"
+checksum = "98c8b05dc14c75ea83d63dd391100353789f5f24b8b3866542a5e85c8be8e985"
 dependencies = [
  "autocfg 1.0.1",
  "bytes 1.0.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ stunclient = "0.1.2"
 threadpool = "1.8.1"
 tracing = "0.1.26"
 tracing-subscriber = "0.2.18"
-tokio = {version = "1.2.0", features = ["full"]}
+tokio = {version = "1.8.0", features = ["full"]}
 uint = { version = "0.8.5", default-features = false }
 validator = { version = "0.13.0", features = ["derive"] }
 

--- a/src/jsonrpc.rs
+++ b/src/jsonrpc.rs
@@ -1,6 +1,8 @@
 use crate::cli::TrinConfig;
+use crate::portalnet::protocol::PortalEndpoint;
 use reqwest::blocking as reqwest;
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use std::fs;
 use std::io::{self, Read, Write};
 use std::net::{TcpListener, TcpStream};
@@ -8,6 +10,8 @@ use std::os::unix;
 use std::sync::Mutex;
 use std::{panic, process};
 use threadpool::ThreadPool;
+use tokio::sync::mpsc::Sender;
+use tokio::sync::oneshot;
 use validator::{Validate, ValidationError};
 
 #[derive(Debug, Deserialize, Serialize, Validate)]
@@ -29,12 +33,21 @@ lazy_static! {
     static ref IPC_PATH: Mutex<String> = Mutex::new(String::new());
 }
 
-pub fn launch_trin(trin_config: TrinConfig, infura_project_id: String) {
+pub fn launch_trin(
+    trin_config: TrinConfig,
+    infura_project_id: String,
+    portal_tx: Sender<PortalEndpoint>,
+) {
     let pool = ThreadPool::new(trin_config.pool_size as usize);
 
     match trin_config.web3_transport.as_str() {
-        "ipc" => launch_ipc_client(pool, infura_project_id, &trin_config.web3_ipc_path),
-        "http" => launch_http_client(pool, infura_project_id, trin_config),
+        "ipc" => launch_ipc_client(
+            pool,
+            infura_project_id,
+            &trin_config.web3_ipc_path,
+            portal_tx,
+        ),
+        "http" => launch_http_client(pool, infura_project_id, trin_config, portal_tx),
         val => panic!("Unsupported web3 transport: {}", val),
     }
 }
@@ -59,7 +72,12 @@ fn set_ipc_cleanup_handlers(ipc_path: &str) {
     }));
 }
 
-fn launch_ipc_client(pool: ThreadPool, infura_project_id: String, ipc_path: &str) {
+fn launch_ipc_client(
+    pool: ThreadPool,
+    infura_project_id: String,
+    ipc_path: &str,
+    portal_tx: Sender<PortalEndpoint>,
+) {
     let listener_result = unix::net::UnixListener::bind(ipc_path);
     let listener = match listener_result {
         Ok(listener) => {
@@ -74,26 +92,33 @@ fn launch_ipc_client(pool: ThreadPool, infura_project_id: String, ipc_path: &str
     for stream in listener.incoming() {
         let stream = stream.unwrap();
         let infura_project_id = infura_project_id.clone();
+        let portal_tx = portal_tx.clone();
         pool.execute(move || {
             let infura_url = get_infura_url(&infura_project_id);
             let mut rx = stream.try_clone().unwrap();
             let mut tx = stream;
-            serve_ipc_client(&mut rx, &mut tx, &infura_url);
+            serve_ipc_client(&mut rx, &mut tx, &infura_url, portal_tx);
         });
     }
     println!("Clean exit");
 }
 
-fn launch_http_client(pool: ThreadPool, infura_project_id: String, trin_config: TrinConfig) {
+fn launch_http_client(
+    pool: ThreadPool,
+    infura_project_id: String,
+    trin_config: TrinConfig,
+    portal_tx: Sender<PortalEndpoint>,
+) {
     let uri = format!("127.0.0.1:{}", trin_config.web3_http_port);
     let listener = TcpListener::bind(uri).unwrap();
     for stream in listener.incoming() {
         match stream {
             Ok(stream) => {
                 let infura_project_id = infura_project_id.clone();
+                let portal_tx = portal_tx.clone();
                 pool.execute(move || {
                     let infura_url = get_infura_url(&infura_project_id);
-                    serve_http_client(stream, &infura_url);
+                    serve_http_client(stream, &infura_url, portal_tx);
                 });
             }
             Err(e) => {
@@ -103,13 +128,18 @@ fn launch_http_client(pool: ThreadPool, infura_project_id: String, trin_config: 
     }
 }
 
-fn serve_ipc_client(rx: &mut impl Read, tx: &mut impl Write, infura_url: &str) {
+fn serve_ipc_client(
+    rx: &mut impl Read,
+    tx: &mut impl Write,
+    infura_url: &str,
+    portal_tx: Sender<PortalEndpoint>,
+) {
     let deser = serde_json::Deserializer::from_reader(rx);
     for obj in deser.into_iter::<JsonRequest>() {
         let obj = obj.unwrap();
         let formatted_response = match obj.validate() {
             Ok(_) => {
-                let result = handle_request(obj, &infura_url);
+                let result = handle_request(obj, &infura_url, portal_tx.clone());
                 match result {
                     Ok(contents) => contents.into_bytes(),
                     Err(contents) => contents.into_bytes(),
@@ -121,7 +151,7 @@ fn serve_ipc_client(rx: &mut impl Read, tx: &mut impl Write, infura_url: &str) {
     }
 }
 
-fn serve_http_client(mut stream: TcpStream, infura_url: &str) {
+fn serve_http_client(mut stream: TcpStream, infura_url: &str, portal_tx: Sender<PortalEndpoint>) {
     let mut buffer = Vec::new();
     stream.read_to_end(&mut buffer).unwrap();
 
@@ -130,7 +160,7 @@ fn serve_http_client(mut stream: TcpStream, infura_url: &str) {
     for obj in deser.into_iter::<JsonRequest>() {
         let obj = obj.unwrap();
         let formatted_response = match obj.validate() {
-            Ok(_) => process_http_request(obj, &infura_url),
+            Ok(_) => process_http_request(obj, &infura_url, portal_tx.clone()),
             Err(e) => format!("HTTP/1.1 400 BAD REQUEST\r\n\r\n{}", e).into_bytes(),
         };
         stream.write_all(&formatted_response).unwrap();
@@ -138,8 +168,12 @@ fn serve_http_client(mut stream: TcpStream, infura_url: &str) {
     }
 }
 
-fn process_http_request(obj: JsonRequest, infura_url: &str) -> Vec<u8> {
-    let result = handle_request(obj, &infura_url);
+fn process_http_request(
+    obj: JsonRequest,
+    infura_url: &str,
+    portal_tx: Sender<PortalEndpoint>,
+) -> Vec<u8> {
+    let result = handle_request(obj, &infura_url, portal_tx);
     match result {
         Ok(contents) => format!(
             "HTTP/1.1 200 OK\r\nContent-Length: {}\r\n\r\n{}",
@@ -156,26 +190,69 @@ fn process_http_request(obj: JsonRequest, infura_url: &str) -> Vec<u8> {
     }
 }
 
-fn handle_request(obj: JsonRequest, infura_url: &str) -> Result<String, String> {
-    let request_id = obj.id;
-    match obj.method.as_str() {
-        "web3_clientVersion" => Ok(format!(
-            r#"{{"jsonrpc":"2.0","id":{},"result":"trin 0.0.1-alpha"}}"#,
-            request_id,
-        )),
-        _ => {
-            //Re-encode json to proxy to Infura
-            let request = serde_json::to_string(&obj).unwrap();
-            match proxy_to_url(request, infura_url) {
-                Ok(result_body) => Ok(std::str::from_utf8(&result_body).unwrap().to_owned()),
-                Err(err) => Err(format!(
-                    r#"{{"jsonrpc":"2.0","id":"{}","error":"Infura failure: {}"}}"#,
-                    request_id,
-                    err.to_string(),
-                )),
-            }
+fn handle_request(
+    obj: JsonRequest,
+    infura_url: &str,
+    portal_tx: Sender<PortalEndpoint>,
+) -> Result<String, String> {
+    let method = obj.method.as_str();
+    if method.starts_with("discv5") {
+        dispatch_portal_request(obj, portal_tx)
+    } else {
+        match method {
+            "web3_clientVersion" => Ok(format!(
+                r#"{{"jsonrpc":"2.0","id":{},"result":"trin 0.0.1-alpha"}}"#,
+                obj.id,
+            )),
+            _ => dispatch_infura_request(obj, infura_url),
         }
     }
+}
+
+fn dispatch_infura_request(obj: JsonRequest, infura_url: &str) -> Result<String, String> {
+    //Re-encode json to proxy to Infura
+    let request = serde_json::to_string(&obj).unwrap();
+    match proxy_to_url(request, infura_url) {
+        Ok(result_body) => Ok(std::str::from_utf8(&result_body).unwrap().to_owned()),
+        Err(err) => Err(format!(
+            r#"{{"jsonrpc":"2.0","id":"{}","error":"Infura failure: {}"}}"#,
+            obj.id,
+            err.to_string(),
+        )),
+    }
+}
+
+#[tokio::main]
+async fn dispatch_portal_request(
+    obj: JsonRequest,
+    portal_tx: Sender<PortalEndpoint>,
+) -> Result<String, String> {
+    let (resp_tx, resp_rx) = oneshot::channel::<Result<Value, String>>();
+    let method = obj.method.as_str();
+    let message = match method {
+        "discv5_nodeInfo" => PortalEndpoint::NodeInfo { resp: resp_tx },
+        "discv5_routingTableInfo" => PortalEndpoint::RoutingTableInfo { resp: resp_tx },
+        _ => {
+            return Err(format!(
+                r#"{{"jsonrpc":"2.0","id":"{}","error":"Unsupported discv5 endpoint: {}"}}"#,
+                obj.id, method,
+            ))
+        }
+    };
+    tokio::task::spawn(async move { portal_tx.send(message).await });
+    let res = match resp_rx.await.unwrap() {
+        Ok(val) => val,
+        Err(msg) => {
+            return Err(format!(
+                r#"{{"jsonrpc":"2.0","id":"{}","error":"Error while processing {}: {}"}}"#,
+                obj.id, method, msg,
+            ))
+        }
+    };
+    Ok(format!(
+        r#"{{"jsonrpc":"2.0","id":{},"result":{}}}"#,
+        obj.id, res,
+    ))
 }
 
 fn proxy_to_url(request: String, url: &str) -> io::Result<Vec<u8>> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,8 +43,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         ..Default::default()
     };
 
-    // Create a new channel with a capacity of at most 32.
-    let (jsonrpc_tx, jsonrpc_rx) = mpsc::channel::<PortalEndpoint>(32);
+    let (jsonrpc_tx, jsonrpc_rx) = mpsc::unbounded_channel::<PortalEndpoint>();
 
     let web3_server_task = tokio::task::spawn_blocking(|| {
         launch_trin(trin_config, infura_project_id, jsonrpc_tx);


### PR DESCRIPTION
Added a [message channel](https://tokio.rs/tokio/tutorial/channels) to serve portal protocol requests over jsonrpc. My first time implementing something like this in rust, so hopefully it's not too clunky.

Added support for a couple basic admin endpoints `discv5_nodeInfo` and `discv5_routingTableInfo`