### PR TITLE
Add default data directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ cd trin
 TRIN_INFURA_PROJECT_ID="YoUr-Id-HeRe" cargo run
 ```
 
+**Optional:** Custom data directory
+```shell
+TRIN_DATA_PATH="/path"
+```
+
 ### Connect over IPC
 In a python shell:
 ```py

--- a/src/portalnet/protocol.rs
+++ b/src/portalnet/protocol.rs
@@ -1,12 +1,12 @@
 #![allow(dead_code)]
 
-use std::env;
 use std::net::SocketAddr;
 use std::sync::Arc;
 
 use super::{
     discovery::{Config as DiscoveryConfig, Discovery},
     types::{FindContent, FindNodes, FoundContent, Nodes, Ping, Pong, Request, Response, SszEnr},
+    utils::get_data_dir,
     U256,
 };
 use super::{types::Message, Enr};
@@ -55,7 +55,7 @@ impl Default for PortalnetConfig {
 }
 
 pub const PROTOCOL: &str = "portal";
-pub const TRIN_DB_ENV_VAR: &str = "TRIN_DB_PATH";
+pub const TRIN_DATA_ENV_VAR: &str = "TRIN_DATA_PATH";
 
 #[derive(Clone)]
 pub struct PortalnetProtocol {
@@ -221,18 +221,11 @@ impl PortalnetProtocol {
             data_radius: portal_config.data_radius,
         };
 
-        let db_path = match env::var(TRIN_DB_ENV_VAR) {
-            Ok(val) => val,
-            Err(_) => panic!(
-                "Must supply target trin db path as environment variable, like:\n\
-                {}=\"/path\"",
-                TRIN_DB_ENV_VAR,
-            ),
-        };
+        let data_path = get_data_dir();
 
         let mut db_opts = Options::default();
         db_opts.create_if_missing(true);
-        let db = DB::open(&db_opts, db_path).unwrap();
+        let db = DB::open(&db_opts, data_path).unwrap();
 
         let events = PortalnetEvents {
             data_radius: portal_config.data_radius,

--- a/src/portalnet/utils.rs
+++ b/src/portalnet/utils.rs
@@ -1,3 +1,6 @@
+use super::protocol::TRIN_DATA_ENV_VAR;
+use std::env;
+
 pub fn xor_two_values(first: &Vec<u8>, second: &Vec<u8>) -> Vec<u8> {
     if &first.len() != &second.len() {
         panic!("Can only xor vectors of equal length.")
@@ -34,5 +37,30 @@ mod test {
         let one = vec![1, 0];
         let two = vec![0, 0, 1];
         xor_two_values(&one, &two);
+    }
+}
+
+pub fn get_data_dir() -> String {
+    match env::var(TRIN_DATA_ENV_VAR) {
+        Ok(data_path) => data_path,
+        Err(_) => get_default_data_dir(),
+    }
+}
+
+pub fn get_default_data_dir() -> String {
+    // Windows: C:\Users\Username\AppData\Roaming\Trin
+    // macOS: ~/Library/Application Support/Trin
+    // Unix-like: ~/.trin
+
+    if cfg!(windows) {
+        let path_ret = env::var("APPDATA").unwrap();
+        format!("{}{}", path_ret, "\\Trin")
+    } else {
+        let path_ret = env::var("Home").unwrap_or(String::from("/"));
+        if cfg!(macos) {
+            format!("{}{}", path_ret, "/Library/Application Support/Trin")
+        } else {
+            format!("{}{}", path_ret, "/.trin")
+        }
     }
 }


### PR DESCRIPTION
This PR just adds default data directories that are used if ``TRIN_DATA_PATH`` (the replacement for ``TRIN_DB_PATH``) isn't set.


```
// Windows: C:\Users\Username\AppData\Roaming\Trin
// macOS: ~/Library/Application Support/Trin
// Unix-like: ~/.trin
```
These are the default data directories for each respected operating system. Just the standard locations with each operating system and normal naming scheme (caps or no caps etc)