### PR TITLE
Bootstrap trin-history network on separate ports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2873,7 +2873,10 @@ dependencies = [
 name = "trin-history"
 version = "0.1.0"
 dependencies = [
+ "log 0.4.14",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
  "trin-core",
 ]
 

--- a/trin-core/src/cli.rs
+++ b/trin-core/src/cli.rs
@@ -1,4 +1,5 @@
 use crate::portalnet::types::HexData;
+use log::info;
 
 use std::env;
 use std::ffi::OsString;
@@ -90,37 +91,44 @@ impl TrinConfig {
     {
         let config = Self::from_iter(args);
 
-        println!("Launching trin...");
-
         match config.web3_transport.as_str() {
             "http" => match &config.web3_ipc_path[..] {
-                DEFAULT_WEB3_IPC_PATH => {
-                    println!(
-                        "Protocol: {}\nWEB3 HTTP port: {}",
-                        config.web3_transport, config.web3_http_port
-                    )
-                }
+                DEFAULT_WEB3_IPC_PATH => {}
                 _ => panic!("Must not supply an ipc path when using http protocol for json-rpc"),
             },
             "ipc" => match &config.web3_http_port.to_string()[..] {
-                DEFAULT_WEB3_HTTP_PORT => {
-                    println!(
-                        "Protocol: {}\nIPC path: {}",
-                        config.web3_transport, config.web3_ipc_path
-                    )
-                }
+                DEFAULT_WEB3_HTTP_PORT => {}
                 _ => panic!("Must not supply an http port when using ipc protocol for json-rpc"),
             },
             val => panic!("Unsupported json-rpc protocol: {}", val),
         }
 
-        println!("Pool Size: {}", config.pool_size);
-
-        match config.bootnodes.is_empty() {
-            true => println!("Bootnodes: None"),
-            _ => println!("Bootnodes: {:?}", config.bootnodes),
-        }
         Ok(config)
+    }
+
+    pub fn display_config(&self) {
+        match self.web3_transport.as_str() {
+            "http" => {
+                info!(
+                    "Protocol: {}\nWEB3 HTTP port: {}",
+                    self.web3_transport, self.web3_http_port
+                )
+            }
+            "ipc" => {
+                info!(
+                    "Protocol: {}\nIPC path: {}",
+                    self.web3_transport, self.web3_ipc_path
+                )
+            }
+            val => panic!("Unsupported json-rpc protocol: {}", val),
+        }
+
+        info!("Pool Size: {}", self.pool_size);
+
+        match self.bootnodes.is_empty() {
+            true => info!("Bootnodes: None"),
+            _ => info!("Bootnodes: {:?}", self.bootnodes),
+        }
     }
 }
 

--- a/trin-history/Cargo.toml
+++ b/trin-history/Cargo.toml
@@ -7,5 +7,8 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+log = "0.4.14"
+tracing = "0.1.26"
+tracing-subscriber = "0.2.18"
 tokio = { version = "1.8.0", features = ["full"] }
 trin-core = { path = "../trin-core" }

--- a/trin-history/src/lib.rs
+++ b/trin-history/src/lib.rs
@@ -1,9 +1,80 @@
+use std::env;
+
+use log::info;
+use tokio::sync::mpsc;
+
+use trin_core::cli::TrinConfig;
+use trin_core::jsonrpc::launch_trin;
+use trin_core::portalnet::protocol::{PortalEndpoint, PortalnetConfig, PortalnetProtocol};
+
 pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("Launching trin-history...");
+
+    let mut trin_config = TrinConfig::new();
+
+    // Set chain history default params
+    trin_config.discovery_port = 9001;
+    trin_config.web3_ipc_path = String::from("/tmp/trin-history-jsonrpc.ipc");
+
+    if trin_config.web3_transport == "http" {
+        trin_config.web3_http_port = 8555;
+    }
+
+    trin_config.display_config();
+
+    let infura_project_id = match env::var("TRIN_INFURA_PROJECT_ID") {
+        Ok(val) => val,
+        Err(_) => panic!(
+            "Must supply Infura key as environment variable, like:\n\
+            TRIN_INFURA_PROJECT_ID=\"your-key-here\" trin"
+        ),
+    };
+
+    let bootnode_enrs = trin_config
+        .bootnodes
+        .iter()
+        .map(|nodestr| nodestr.parse().unwrap())
+        .collect();
+
+    let portalnet_config = PortalnetConfig {
+        external_addr: trin_config.external_addr,
+        private_key: trin_config.private_key.clone(),
+        listen_port: trin_config.discovery_port,
+        bootnode_enrs,
+        ..Default::default()
+    };
+
+    let (jsonrpc_tx, jsonrpc_rx) = mpsc::unbounded_channel::<PortalEndpoint>();
+
+    let web3_server_task = tokio::task::spawn_blocking(|| {
+        launch_trin(trin_config, infura_project_id, jsonrpc_tx);
+    });
+
+    info!(
+        "About to spawn portal p2p with boot nodes: {:?}",
+        portalnet_config.bootnode_enrs
+    );
+
     tokio::spawn(async move {
-        println!("Hello, from the history network!");
+        let (mut p2p, events, rpc_handler) = PortalnetProtocol::new(portalnet_config, jsonrpc_rx)
+            .await
+            .unwrap();
+
+        tokio::join!(
+            events.process_discv5_requests(),
+            rpc_handler.process_jsonrpc_requests()
+        );
+
+        // hacky test: make sure we establish a session with the boot node
+        p2p.ping_bootnodes().await.unwrap();
+
+        tokio::signal::ctrl_c()
+            .await
+            .expect("failed to pause until ctrl-c");
     })
     .await
     .unwrap();
 
+    web3_server_task.await.unwrap();
     Ok(())
 }

--- a/trin-history/src/main.rs
+++ b/trin-history/src/main.rs
@@ -1,4 +1,6 @@
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt::init();
+
     trin_history::main().await
 }

--- a/trin-state/src/lib.rs
+++ b/trin-state/src/lib.rs
@@ -8,9 +8,10 @@ use trin_core::jsonrpc::launch_trin;
 use trin_core::portalnet::protocol::{PortalEndpoint, PortalnetConfig, PortalnetProtocol};
 
 pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    tracing_subscriber::fmt::init();
+    println!("Launching trin-state...");
 
     let trin_config = TrinConfig::new();
+    trin_config.display_config();
 
     let infura_project_id = match env::var("TRIN_INFURA_PROJECT_ID") {
         Ok(val) => val,

--- a/trin-state/src/main.rs
+++ b/trin-state/src/main.rs
@@ -1,4 +1,6 @@
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt::init();
+
     trin_state::main().await
 }


### PR DESCRIPTION
Bootstrap `trin-history` network by changing the default ports to not match `trin-state`. It also adds method to display the config values.

This is a hack until we make StructOpt handle CLI simultaneously for both networks.