### PR TITLE
Bug fix waiting for non completing tasks to return

### DIFF
--- a/trin-history/src/lib.rs
+++ b/trin-history/src/lib.rs
@@ -60,10 +60,8 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .await
             .unwrap();
 
-        tokio::join!(
-            events.process_discv5_requests(),
-            rpc_handler.process_jsonrpc_requests()
-        );
+        tokio::spawn(events.process_discv5_requests());
+        tokio::spawn(rpc_handler.process_jsonrpc_requests());
 
         // hacky test: make sure we establish a session with the boot node
         p2p.ping_bootnodes().await.unwrap();

--- a/trin-state/src/lib.rs
+++ b/trin-state/src/lib.rs
@@ -51,10 +51,8 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .await
             .unwrap();
 
-        tokio::join!(
-            events.process_discv5_requests(),
-            rpc_handler.process_jsonrpc_requests()
-        );
+        tokio::spawn(events.process_discv5_requests());
+        tokio::spawn(rpc_handler.process_jsonrpc_requests());
 
         // hacky test: make sure we establish a session with the boot node
         p2p.ping_bootnodes().await.unwrap();


### PR DESCRIPTION
I was unsuccessfully trying to connect `trin-state` with `ddht`  using [this](https://gist.github.com/carver/f3c26d9adb28ea2b4e5d5bbe42b4f4b7) guide. 
After some debugging with `netcat`, the sockets and udp ports looked fine. Then I started to look into the code and realized that `tokio;;join!` is waiting for  `process_discv5_requests` and `process_jsonrpc_requests` to complete before executing `p2p.ping_bootnodes().await.unwrap();`. 

I'm new to tokio, but I think this is probably the simplest fix for now.