### PR TITLE
Implement distance function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,6 +187,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63396b8a4b9de3f4fdfb320ab6080762242f66a8ef174c49d8e19b674db4cdbe"
 
 [[package]]
+name = "byte-slice-cast"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65c1bf4a04a88c54f589125563643d773f3254b5c38571395e2b591c693bbc81"
+
+[[package]]
 name = "bytecodec"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -572,7 +578,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5785a82b7bf7c817e2648d0159a0df29b16c2314e039b9789acc9643db86ab0a"
 dependencies = [
- "ethereum-types",
+ "ethereum-types 0.5.2",
 ]
 
 [[package]]
@@ -592,10 +598,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3932e82d64d347a045208924002930dc105a138995ccdc1479d0f05f0359f17c"
 dependencies = [
  "crunchy",
- "fixed-hash",
- "impl-rlp",
- "impl-serde",
- "tiny-keccak",
+ "fixed-hash 0.3.2",
+ "impl-rlp 0.2.1",
+ "impl-serde 0.2.3",
+ "tiny-keccak 1.5.0",
+]
+
+[[package]]
+name = "ethbloom"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "779864b9c7f7ead1f092972c3257496c6a84b46dba2ce131dd8a282cb2cc5972"
+dependencies = [
+ "crunchy",
+ "fixed-hash 0.7.0",
+ "impl-rlp 0.3.0",
+ "impl-serde 0.3.1",
+ "tiny-keccak 2.0.2",
 ]
 
 [[package]]
@@ -605,11 +624,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b054df51e53f253837ea422681215b42823c02824bde982699d0dceecf6165a1"
 dependencies = [
  "crunchy",
- "ethbloom",
+ "ethbloom 0.6.4",
  "ethereum-types-serialize",
- "fixed-hash",
+ "fixed-hash 0.3.2",
  "serde",
  "uint 0.5.0",
+]
+
+[[package]]
+name = "ethereum-types"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dd6bde671199089e601e8d47e153368b893ef885f11f365a3261ec58153c211"
+dependencies = [
+ "ethbloom 0.11.0",
+ "fixed-hash 0.7.0",
+ "impl-rlp 0.3.0",
+ "impl-serde 0.3.1",
+ "primitive-types",
+ "uint 0.9.0",
 ]
 
 [[package]]
@@ -643,6 +676,18 @@ dependencies = [
  "rand 0.5.6",
  "rustc-hex",
  "static_assertions 0.2.5",
+]
+
+[[package]]
+name = "fixed-hash"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcf0ed7fe52a17a03854ec54a9f76d6d84508d1c0e66bc1793301c73fc8493c"
+dependencies = [
+ "byteorder",
+ "rand 0.8.3",
+ "rustc-hex",
+ "static_assertions 1.1.0",
 ]
 
 [[package]]
@@ -1061,6 +1106,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f7280c75fb2e2fc47080ec80ccc481376923acb04501957fc38f935c3de5088"
 
 [[package]]
+name = "impl-codec"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "161ebdfec3c8e3b52bf61c4f3550a1eea4f9579d10dc1b936f3171ebdcd6c443"
+dependencies = [
+ "parity-scale-codec",
+]
+
+[[package]]
 name = "impl-rlp"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1070,12 +1124,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "impl-rlp"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28220f89297a075ddc7245cd538076ee98b01f2a9c23a53a4f1105d5a322808"
+dependencies = [
+ "rlp 0.5.0",
+]
+
+[[package]]
 name = "impl-serde"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58e3cae7e99c7ff5a995da2cf78dd0a5383740eda71d98cf7b1910c301ac69b8"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "impl-serde"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b47ca4d2b6931707a55fce5cf66aff80e2178c8b63bbb4ecb5695cbc870ddf6f"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "impl-trait-for-tuples"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5dacb10c5b3bb92d46ba347505a9041e676bb20ad220101326bffb0c93031ee"
+dependencies = [
+ "proc-macro2 1.0.26",
+ "quote 1.0.9",
+ "syn 1.0.72",
 ]
 
 [[package]]
@@ -1454,12 +1537,69 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43db66d1170d347f9a065114077f7dccb00c1b9478c89384490a3425279a4606"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e0d047c1062aa51e256408c560894e5251f08925980e53cf1aa5bd00eec6512"
+dependencies = [
+ "autocfg 1.0.1",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26873667bbbb7c5182d4a37c1add32cdf09f841af72da53318fdb81543c15085"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
 dependencies = [
  "autocfg 1.0.1",
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2021c8337a54d21aca0d59a92577a029af9431cb59b909b03252b9c164fad59"
+dependencies = [
+ "autocfg 1.0.1",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d41702bd167c2df5520b384281bc111a4b5efcf7fbc4c9c222c815b07e0a6a6a"
+dependencies = [
+ "autocfg 1.0.1",
+ "num-bigint",
+ "num-integer",
  "num-traits",
 ]
 
@@ -1525,6 +1665,32 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "parity-scale-codec"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8975095a2a03bbbdc70a74ab11a4f76a6d0b84680d87c68d722531b0ac28e8a9"
+dependencies = [
+ "arrayvec",
+ "bitvec",
+ "byte-slice-cast",
+ "impl-trait-for-tuples",
+ "parity-scale-codec-derive",
+ "serde",
+]
+
+[[package]]
+name = "parity-scale-codec-derive"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40dbbfef7f0a1143c5b06e0d76a6278e25dac0bc1af4be51a0fbb73f07e7ad09"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2 1.0.26",
+ "quote 1.0.9",
+ "syn 1.0.72",
 ]
 
 [[package]]
@@ -1660,6 +1826,29 @@ name = "ppv-lite86"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+
+[[package]]
+name = "primitive-types"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05e4722c697a58a99d5d06a08c30821d7c082a4632198de1eaa5a6c22ef42373"
+dependencies = [
+ "fixed-hash 0.7.0",
+ "impl-codec",
+ "impl-rlp 0.3.0",
+ "impl-serde 0.3.1",
+ "uint 0.9.0",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fdbd1df62156fbc5945f4762632564d7d038153091c3fcf1067f6aef7cff92"
+dependencies = [
+ "thiserror",
+ "toml",
+]
 
 [[package]]
 name = "proc-macro-error"
@@ -2512,6 +2701,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93119e4feac1cbe6c798c34d3a53ea0026b0b1de6a120deef895137c0529bfe2"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "060d69a0afe7796bf42e9e2ff91f5ee691fb15c53d38b4b62a9a53eb23164745"
+dependencies = [
+ "proc-macro2 1.0.26",
+ "quote 1.0.9",
+ "syn 1.0.72",
+]
+
+[[package]]
 name = "thread_local"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2543,6 +2752,15 @@ name = "tiny-keccak"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d8a021c69bb74a44ccedb824a046447e2c84a01df9e5c20779750acb38e11b2"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
 dependencies = [
  "crunchy",
 ]
@@ -2718,6 +2936,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "tower-service"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2849,12 +3076,14 @@ dependencies = [
  "env_logger",
  "eth2_ssz",
  "eth2_ssz_derive",
+ "ethereum-types 0.12.0",
  "futures 0.3.14",
  "hex",
  "interfaces",
  "ipconfig",
  "lazy_static 1.4.0",
  "log 0.4.14",
+ "num",
  "reqwest",
  "rlp 0.5.0",
  "rocksdb",

--- a/trin-core/Cargo.toml
+++ b/trin-core/Cargo.toml
@@ -4,24 +4,26 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-hex = "0.4.3"
-structopt = "0.3"
-clap = "2.33.3"
-directories = "3.0"
-stunclient = "0.1.2"
-log = "0.4.14"
 base64 = "0.13.0"
+clap = "2.33.3"
 ctrlc = "3.1.8"
+directories = "3.0"
 env_logger = "0.8.2"
 eth2_ssz = "0.1.2"
 eth2_ssz_derive = "0.1.0"
+ethereum-types = "0.12.0"
 futures = "0.3.13"
+hex = "0.4.3"
 lazy_static = "1.4.0"
+log = "0.4.14"
+num = "0.4.0"
 reqwest = { version = "0.11.0", features = ["blocking"] }
 rlp = "0.5.0"
 rocksdb = "0.16.0"
 serde = {version = "1.0.125", features = ["derive"] }
 serde_json = "1.0.59"
+structopt = "0.3"
+stunclient = "0.1.2"
 threadpool = "1.8.1"
 tokio = {version = "1.8.0", features = ["full"]}
 uint = { version = "0.8.5", default-features = false }

--- a/trin-core/src/utils.rs
+++ b/trin-core/src/utils.rs
@@ -1,6 +1,9 @@
 use directories::ProjectDirs;
 use std::{env, fs};
 
+use num::bigint::{BigInt, Sign};
+use num::Signed;
+
 const TRIN_DATA_ENV_VAR: &str = "TRIN_DATA_PATH";
 
 pub fn xor_two_values(first: &[u8], second: &[u8]) -> Vec<u8> {
@@ -15,9 +18,67 @@ pub fn xor_two_values(first: &[u8], second: &[u8]) -> Vec<u8> {
         .collect()
 }
 
+// 2 ** 256
+const MODULO: [u8; 78] = [
+    49, 49, 53, 55, 57, 50, 48, 56, 57, 50, 51, 55, 51, 49, 54, 49, 57, 53, 52, 50, 51, 53, 55, 48,
+    57, 56, 53, 48, 48, 56, 54, 56, 55, 57, 48, 55, 56, 53, 51, 50, 54, 57, 57, 56, 52, 54, 54, 53,
+    54, 52, 48, 53, 54, 52, 48, 51, 57, 52, 53, 55, 53, 56, 52, 48, 48, 55, 57, 49, 51, 49, 50, 57,
+    54, 51, 57, 57, 51, 54,
+];
+
+// 2 ** 255
+const MID: [u8; 77] = [
+    53, 55, 56, 57, 54, 48, 52, 52, 54, 49, 56, 54, 53, 56, 48, 57, 55, 55, 49, 49, 55, 56, 53, 52,
+    57, 50, 53, 48, 52, 51, 52, 51, 57, 53, 51, 57, 50, 54, 54, 51, 52, 57, 57, 50, 51, 51, 50, 56,
+    50, 48, 50, 56, 50, 48, 49, 57, 55, 50, 56, 55, 57, 50, 48, 48, 51, 57, 53, 54, 53, 54, 52, 56,
+    49, 57, 57, 54, 56,
+];
+
+// distance function as defined at...
+// https://notes.ethereum.org/h58LZcqqRRuarxx4etOnGQ#Storage-Layout
+// todo: measure & optimize
+pub fn distance(node_id: BigInt, content_id: BigInt) -> BigInt {
+    let modulo = BigInt::parse_bytes(&MODULO, 10).unwrap();
+    let mid = BigInt::parse_bytes(&MID, 10).unwrap();
+    let negative_mid = mid
+        .checked_mul(&BigInt::from_bytes_le(Sign::Minus, &[1u8]))
+        .unwrap();
+
+    let first_phrase = node_id - content_id + &mid;
+    // % returns the remainder, we want to return the modulus
+    let modulus_result = ((first_phrase % &modulo) + &modulo) % &modulo;
+    let delta = modulus_result - &mid;
+    match delta < negative_mid {
+        true => (delta + mid).abs(),
+        _ => delta.abs(),
+    }
+}
+
+pub fn get_data_dir() -> String {
+    let path = env::var(TRIN_DATA_ENV_VAR).unwrap_or_else(|_| get_default_data_dir());
+
+    fs::create_dir_all(&path).expect("Unable to create data directory folder");
+    path
+}
+
+pub fn get_default_data_dir() -> String {
+    // Windows: C:\Users\Username\AppData\Roaming\Trin\data
+    // macOS: ~/Library/Application Support/Trin
+    // Unix-like: ~/.trin
+
+    match ProjectDirs::from("", "", "Trin") {
+        Some(proj_dirs) => proj_dirs.data_local_dir().to_str().unwrap().to_string(),
+        None => panic!("Unable to find data directory"),
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
+
+    // 2 ** 256 - 1
+    const MOD_SUB_ONE: &[u8] =
+        "115792089237316195423570985008687907853269984665640564039457584007913129639935".as_bytes();
 
     #[test]
     fn test_xor_two_zeros() {
@@ -40,22 +101,73 @@ mod test {
         let two = vec![0, 0, 1];
         xor_two_values(&one, &two);
     }
-}
 
-pub fn get_data_dir() -> String {
-    let path = env::var(TRIN_DATA_ENV_VAR).unwrap_or_else(|_| get_default_data_dir());
+    // test cases yanked from: https://notes.ethereum.org/h58LZcqqRRuarxx4etOnGQ
+    #[test]
+    fn test_distance_zeros() {
+        let content_id = BigInt::parse_bytes("10".as_bytes(), 10).unwrap();
+        let node_id = BigInt::parse_bytes("10".as_bytes(), 10).unwrap();
+        let expected = BigInt::parse_bytes("0".as_bytes(), 10).unwrap();
+        let calculated_distance = distance(content_id, node_id);
+        assert_eq!(calculated_distance, expected);
+    }
 
-    fs::create_dir_all(&path).expect("Unable to create data directory folder");
-    path
-}
+    #[test]
+    fn test_distance_one() {
+        let content_id = BigInt::parse_bytes("5".as_bytes(), 10).unwrap();
+        let node_id = BigInt::parse_bytes("1".as_bytes(), 10).unwrap();
+        let expected = BigInt::parse_bytes("4".as_bytes(), 10).unwrap();
+        let calculated_distance = distance(content_id.clone(), node_id.clone());
+        assert_eq!(calculated_distance, expected);
+        let reversed = distance(node_id, content_id);
+        assert_eq!(reversed, expected);
+    }
 
-pub fn get_default_data_dir() -> String {
-    // Windows: C:\Users\Username\AppData\Roaming\Trin\data
-    // macOS: ~/Library/Application Support/Trin
-    // Unix-like: ~/.trin
+    #[test]
+    fn test_distance_two() {
+        let content_id = BigInt::parse_bytes("5".as_bytes(), 10).unwrap();
+        let node_id = BigInt::parse_bytes(MOD_SUB_ONE, 10).unwrap();
+        let expected = BigInt::parse_bytes("6".as_bytes(), 10).unwrap();
+        let calculated_distance = distance(content_id, node_id);
+        assert_eq!(calculated_distance, expected);
+    }
 
-    match ProjectDirs::from("", "", "Trin") {
-        Some(proj_dirs) => proj_dirs.data_local_dir().to_str().unwrap().to_string(),
-        None => panic!("Unable to find data directory"),
+    #[test]
+    fn test_distance_three() {
+        let content_id = BigInt::parse_bytes(MOD_SUB_ONE, 10).unwrap();
+        let node_id = BigInt::parse_bytes("6".as_bytes(), 10).unwrap();
+        let expected = BigInt::parse_bytes("7".as_bytes(), 10).unwrap();
+        let calculated_distance = distance(content_id, node_id);
+        assert_eq!(calculated_distance, expected);
+    }
+
+    #[test]
+    fn test_distance_four() {
+        let content_id = BigInt::parse_bytes("0".as_bytes(), 10).unwrap();
+        let node_id = BigInt::parse_bytes(&MID, 10).unwrap();
+        let expected = BigInt::parse_bytes(&MID, 10).unwrap();
+        let calculated_distance = distance(content_id, node_id);
+        assert_eq!(calculated_distance, expected);
+    }
+
+    #[test]
+    fn test_distance_five() {
+        let content_id = BigInt::parse_bytes("0".as_bytes(), 10).unwrap();
+        // 2 ** 255 + 1
+        let node_id = BigInt::parse_bytes(
+            "57896044618658097711785492504343953926634992332820282019728792003956564819969"
+                .as_bytes(),
+            10,
+        )
+        .unwrap();
+        // 2 ** 255 - 1
+        let expected = BigInt::parse_bytes(
+            "57896044618658097711785492504343953926634992332820282019728792003956564819967"
+                .as_bytes(),
+            10,
+        )
+        .unwrap();
+        let calculated_distance = distance(content_id, node_id);
+        assert_eq!(calculated_distance, expected);
     }
 }


### PR DESCRIPTION
Implement new distance function & tests as defined at 
https://notes.ethereum.org/h58LZcqqRRuarxx4etOnGQ#Storage-Layout

Uses the [num::bigint](https://docs.rs/num/0.4.0/num/bigint/struct.BigInt.html) library - which might not be the most efficient way to do things? it seemed like the [`ethereum-types` - `U256`](https://docs.rs/ethereum-types/0.12.0/ethereum_types/struct.U256.html) wasn't ideal for the calculations needed here. Either way, I'm open to changing the argument types here to whatever people think is the most useful. 

This is also probably not the most performant way to handle this calculation - and as it's likely to be used a lot, further optimizations down the road would probably become very useful.