### PR TITLE
Reduce clippy to only run for trin

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,14 +29,12 @@ jobs:
             - run:
                 name: Run rustfmt
                 command: cargo fmt -- --check
-            # Run the sub-commands of the orb jobs separately, since the combined steps for Clippy can be long enough to trigger a timeout (>10min). Building the source is the main contributor.
             - run:
                 name: Install Clippy
                 command: rustup component add clippy
             - run:
                 name: Run Clippy
                 command: cargo clippy --package trin -- --deny warnings
-                no_output_timeout: 20m
             - rust/build:
                 release: false
                 with_cache: false
@@ -70,7 +68,6 @@ jobs:
       - run:
           name: Install target toolchain
           command: rustup toolchain install stable-x86_64-pc-windows-msvc
-      # Run the sub-commands of the orb jobs separately, since the combined steps for Clippy can be long enough to trigger a timeout (>10min). Building the source is the main contributor.
       - run:
           name: Install Clippy
           command: rustup component add clippy
@@ -80,7 +77,6 @@ jobs:
           command: |
             (gc ..\.gitconfig | select -Skip 2) | sc ..\.gitconfig
             cargo clippy --package trin -- --deny warnings
-          no_output_timeout: 20m
       - run:
           name: Cargo Build --target x86_64-pc-windows-msvc
           command: cargo build --target x86_64-pc-windows-msvc

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,7 @@ jobs:
           # Remove the first two lines of gitconfig as work around
           command: |
             (gc ..\.gitconfig | select -Skip 2) | sc ..\.gitconfig
-            cargo clippy -- --deny warnings
+            cargo clippy --package trin -- --deny warnings
           no_output_timeout: 20m
       - run:
           name: Cargo Build --target x86_64-pc-windows-msvc

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
                 command: rustup component add clippy
             - run:
                 name: Run Clippy
-                command: cargo clippy -- --deny warnings
+                command: cargo clippy --package trin -- --deny warnings
                 no_output_timeout: 20m
             - rust/build:
                 release: false


### PR DESCRIPTION
Clippy now only checks the trin crates - reduces job time from ~8mins to ~8secs

Fixes #71 

From circle output
```
    Checking trin-core v0.1.0 (/home/circleci/project/trin-core)
    Checking trin-state v0.1.0 (/home/circleci/project/trin-state)
    Checking trin-history v0.1.0 (/home/circleci/project/trin-history)
    Checking trin v0.1.0 (/home/circleci/project)
```