### PR TITLE
add default data path for unix to README and comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,12 @@ cargo run -p trin-state|trin-history
 
 **Optional:** Custom data directory
 ```shell
-TRIN_DATA_PATH="/path"
+TRIN_DATA_PATH="/your_path"
 ```
+*Note, default data paths are:*\
+Linux/Unix - `$HOME/.local/share/trin`\
+MacOS - `~/Library/Application Support/Trin`\
+Windows - `C:\Users\Username\AppData\Roaming\Trin\data`
 
 ### Connect over IPC
 In a python shell:

--- a/trin-core/src/utils.rs
+++ b/trin-core/src/utils.rs
@@ -52,7 +52,7 @@ pub fn get_data_dir() -> String {
 pub fn get_default_data_dir() -> String {
     // Windows: C:\Users\Username\AppData\Roaming\Trin\data
     // macOS: ~/Library/Application Support/Trin
-    // Unix-like: ~/.trin
+    // Unix-like: $HOME/.local/share/trin
 
     match ProjectDirs::from("", "", "Trin") {
         Some(proj_dirs) => proj_dirs.data_local_dir().to_str().unwrap().to_string(),


### PR DESCRIPTION
same changes as this [PR](https://github.com/carver/trin/pull/68) but I removed the superfluous "merge" commits so now it's just one commit.