### PR TITLE
Remove jsonrpc dependency from PortalnetProtocol struct and change default folder name

### DIFF
--- a/trin-core/src/portalnet/protocol.rs
+++ b/trin-core/src/portalnet/protocol.rs
@@ -73,8 +73,8 @@ pub struct PortalnetEvents {
 }
 
 pub struct JsonRpcHandler {
-    discovery: Arc<Discovery>,
-    jsonrpc_rx: mpsc::UnboundedReceiver<PortalEndpoint>,
+    pub discovery: Arc<Discovery>,
+    pub jsonrpc_rx: mpsc::UnboundedReceiver<PortalEndpoint>,
 }
 
 impl JsonRpcHandler {
@@ -185,10 +185,7 @@ impl PortalnetEvents {
 }
 
 impl PortalnetProtocol {
-    pub async fn new(
-        portal_config: PortalnetConfig,
-        jsonrpc_rx: mpsc::UnboundedReceiver<PortalEndpoint>,
-    ) -> Result<(Self, PortalnetEvents, JsonRpcHandler), String> {
+    pub async fn new(portal_config: PortalnetConfig) -> Result<(Self, PortalnetEvents), String> {
         let listen_all_ips = SocketAddr::new("0.0.0.0".parse().unwrap(), portal_config.listen_port);
 
         let external_addr = portal_config
@@ -222,12 +219,6 @@ impl PortalnetProtocol {
         );
 
         let discovery = Arc::new(discovery);
-
-        let proto = Self {
-            discovery: discovery.clone(),
-            overlay: overlay.clone(),
-        };
-
         let data_path = get_data_dir();
 
         let mut db_opts = Options::default();
@@ -241,12 +232,12 @@ impl PortalnetProtocol {
             db,
         };
 
-        let rpc_handler = JsonRpcHandler {
-            discovery,
-            jsonrpc_rx,
+        let proto = Self {
+            discovery: discovery.clone(),
+            overlay: overlay.clone(),
         };
 
-        Ok((proto, events, rpc_handler))
+        Ok((proto, events))
     }
 
     pub async fn send_ping(&self, data_radius: U256, enr: Enr) -> Result<Vec<u8>, String> {

--- a/trin-core/src/portalnet/protocol.rs
+++ b/trin-core/src/portalnet/protocol.rs
@@ -219,7 +219,7 @@ impl PortalnetProtocol {
         );
 
         let discovery = Arc::new(discovery);
-        let data_path = get_data_dir();
+        let data_path = get_data_dir(discovery.local_enr());
 
         let mut db_opts = Options::default();
         db_opts.create_if_missing(true);

--- a/trin-core/src/utils.rs
+++ b/trin-core/src/utils.rs
@@ -1,3 +1,4 @@
+use crate::portalnet::Enr;
 use directories::ProjectDirs;
 use std::{env, fs};
 
@@ -42,19 +43,25 @@ mod test {
     }
 }
 
-pub fn get_data_dir() -> String {
-    let path = env::var(TRIN_DATA_ENV_VAR).unwrap_or_else(|_| get_default_data_dir());
+pub fn get_data_dir(local_enr: Enr) -> String {
+    let path = env::var(TRIN_DATA_ENV_VAR).unwrap_or_else(|_| get_default_data_dir(local_enr));
 
     fs::create_dir_all(&path).expect("Unable to create data directory folder");
     path
 }
 
-pub fn get_default_data_dir() -> String {
+pub fn get_default_data_dir(local_enr: Enr) -> String {
     // Windows: C:\Users\Username\AppData\Roaming\Trin\data
     // macOS: ~/Library/Application Support/Trin
     // Unix-like: $HOME/.local/share/trin
 
-    match ProjectDirs::from("", "", "Trin") {
+    // Append last 8 enr base64 encoded chars to application dir name
+    let mut application_string = "Trin_".to_owned();
+    let len = &local_enr.to_base64().len();
+    let suffix = &local_enr.to_base64()[len - 8..];
+    application_string.push_str(suffix);
+
+    match ProjectDirs::from("", "", &application_string) {
         Some(proj_dirs) => proj_dirs.data_local_dir().to_str().unwrap().to_string(),
         None => panic!("Unable to find data directory"),
     }

--- a/trin-history/src/lib.rs
+++ b/trin-history/src/lib.rs
@@ -5,7 +5,9 @@ use tokio::sync::mpsc;
 
 use trin_core::cli::TrinConfig;
 use trin_core::jsonrpc::launch_trin;
-use trin_core::portalnet::protocol::{PortalEndpoint, PortalnetConfig, PortalnetProtocol};
+use trin_core::portalnet::protocol::{
+    JsonRpcHandler, PortalEndpoint, PortalnetConfig, PortalnetProtocol,
+};
 
 pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Launching trin-history...");
@@ -56,9 +58,12 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
     );
 
     tokio::spawn(async move {
-        let (mut p2p, events, rpc_handler) = PortalnetProtocol::new(portalnet_config, jsonrpc_rx)
-            .await
-            .unwrap();
+        let (mut p2p, events) = PortalnetProtocol::new(portalnet_config).await.unwrap();
+
+        let rpc_handler = JsonRpcHandler {
+            discovery: p2p.discovery.clone(),
+            jsonrpc_rx,
+        };
 
         tokio::spawn(events.process_discv5_requests());
         tokio::spawn(rpc_handler.process_jsonrpc_requests());


### PR DESCRIPTION
Sometimes, we may want to initialize a portal net protocol without jsonrpc support (for example when running tests or creating "dummy" node).

It will be also good if we can run multiple portal protocol instances simultaneously (for testing req/resp network calls). The current default db folder structure prevent this, because there is a db collusion between the different instances.

This PR removes jsonrpc dependency from PortalnetProtocol struct and adds last 8 chars from local base64 encoded Enr as a suffix to the default data application folder.